### PR TITLE
Not re-encode audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # ripdiko
 
-ripdiko rips radiko.jp streams and encodes them in MP3. Metadata such as program title, station name and recording length is automatically determined by fetching the metadata via Radiko's (supposedly unofficial) API, and embedded in the output audio file.
+ripdiko rips radiko.jp streams. Metadata such as program title, station name and recording length is automatically determined by fetching the metadata via Radiko's (supposedly unofficial) API, and embedded in the output audio file.
 
 ## How to use
 
 Set up environment variables:
 
-- `RIPDIKO_OUTDIR`: Output directory to save ripped MP3 files. Defaults to `~/Music/Radiko`
-- `RIPDIKO_BITRATE`: Bitrate for re-encoded MP3. 64kbps by default (Radiko upstram is served around 48kbps)
+- `RIPDIKO_OUTDIR`: Output directory to save ripped M4A files. Defaults to `~/Music/Radiko`
 
 Run `ripdiko <station-id>` where station ID is `TBS`, `LFR`, `FMJ` etc. The script will end when the currently playing program ends (which is automatically figured out by using the API).
 

--- a/bin/ripdiko
+++ b/bin/ripdiko
@@ -47,7 +47,7 @@ class DownloadTask
   PLAYER_URL = "https://radiko.jp/apps/js/flash/myplayer-release.swf"
   TMPDIR = ENV['TMPDIR'] || '/tmp'
 
-  attr_accessor :station, :buffer, :outdir, :bitrate
+  attr_accessor :station, :buffer, :outdir
 
   def initialize(station = nil, duration = 1800, *args)
     unless station
@@ -57,7 +57,6 @@ class DownloadTask
     @duration = duration
     @buffer = ENV['RIPDIKO_BUFFER'] || 60
     @outdir = ENV['RIPDIKO_OUTDIR'] || "#{ENV['HOME']}/Music/Radiko"
-    @bitrate = ENV['RIPDIKO_BITRATE'] || '64k'
     @output = ENV['RIPDIKO_OUTPUT'] == nil ? "file" : ENV['RIPDIKO_OUTPUT']
   end
 
@@ -134,18 +133,18 @@ class DownloadTask
 
     duration = program.recording_duration + buffer
 
-    tempfile = "#{TMPDIR}/#{program.id}.mp3"
+    tempfile = "#{TMPDIR}/#{program.id}.m4a"
 
     case @output
     when "fifo" then
       require 'mkfifo'
-      tempfile = "#{TMPDIR}/fifo.mp3"
+      tempfile = "#{TMPDIR}/fifo.m4a"
       if File.exist? tempfile
         FileUtils.rm tempfile
       end
       File.mkfifo tempfile
     when "stdout"
-      tempfile = "-f mp3 -"
+      tempfile = "-f m4a -"
     end
 
     puts "Streaming #{program.title} ~ #{program.to.strftime("%H:%M")} (#{duration}s)"
@@ -167,7 +166,7 @@ class DownloadTask
       -metadata album="#{program.title}"
       -metadata genre=Radio
       -metadata year="#{program.effective_date.year}"
-      -acodec libmp3lame -ar 44100 -ab #{bitrate} -ac 2
+      -c copy
       #{tempfile}
     )
 
@@ -176,7 +175,7 @@ class DownloadTask
     case @output
     when "file" then
       FileUtils.mkpath(outdir)
-      File.rename tempfile, "#{outdir}/#{program.id}.mp3"
+      File.rename tempfile, "#{outdir}/#{program.id}.m4a"
 
       notification = {
         :program => {


### PR DESCRIPTION
Uses ffmpeg's `-c copy` to copy the stream, and outputs to a `.m4a` file, because re-encoding lossy audio is bad.
I don't know ruby so I have no idea if I've done this in a right-thinking manner, but I've tested it and it seems to work.